### PR TITLE
Update lambda runtime to nodejs18x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ resource "aws_lambda_function" "lambda_origin_request" {
   function_name    = "${module.label.id}_lambda_origin_request"
   filename         = data.archive_file.lambda_origin_request_zip_file.output_path
   source_code_hash = data.archive_file.lambda_origin_request_zip_file.output_base64sha256
-  runtime          = "nodejs14.x"
+  runtime          = "nodejs18.x"
   handler          = "index.handler"
   publish          = true
 }
@@ -252,7 +252,7 @@ resource "aws_lambda_function" "lambda_viewer_request" {
   function_name    = "${module.label.id}_lambda_viewer_request"
   filename         = data.archive_file.lambda_viewer_request_zip_file.output_path
   source_code_hash = data.archive_file.lambda_viewer_request_zip_file.output_base64sha256
-  runtime          = "nodejs14.x"
+  runtime          = "nodejs18.x"
   handler          = "index.handler"
   publish          = true
 }


### PR DESCRIPTION
NodeJS 14 reached EOL on April 30, 2023.

AWS suggest bumping to v18 before November 27