### PR TITLE
Upgrade Lambda runtime to nodejs20.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ resource "aws_lambda_function" "lambda_origin_request" {
   function_name    = "${module.label.id}_lambda_origin_request"
   filename         = data.archive_file.lambda_origin_request_zip_file.output_path
   source_code_hash = data.archive_file.lambda_origin_request_zip_file.output_base64sha256
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
   publish          = true
 }
@@ -252,7 +252,7 @@ resource "aws_lambda_function" "lambda_viewer_request" {
   function_name    = "${module.label.id}_lambda_viewer_request"
   filename         = data.archive_file.lambda_viewer_request_zip_file.output_path
   source_code_hash = data.archive_file.lambda_viewer_request_zip_file.output_base64sha256
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
   publish          = true
 }


### PR DESCRIPTION
## Summary
- Upgrades both Lambda functions (`lambda_origin_request` and `lambda_viewer_request`) from `nodejs18.x` to `nodejs20.x`
- Node.js 18 reached end of support on AWS Lambda on March 9, 2026

## Test plan
- [ ] Verify Lambda functions deploy successfully with nodejs20.x runtime
- [ ] Verify origin request and viewer request handlers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)