### PR TITLE
Upgrade Go version from 1.24.0 to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nagelflorian/aws-s3-review-apps
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
## Summary
- Upgrades Go version in `go.mod` from 1.24.0 to 1.26.0 (latest)

## Test plan
- [x] Verify Go tests compile and pass with Go 1.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)