### PR TITLE
Add Terraform fmt and validate checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,21 @@ on:
     branches: [master]
 
 jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+      - name: Terraform Init
+        run: terraform init -backend=false
+      - name: Terraform Validate
+        run: terraform validate
+
   test:
+    name: Node.js Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Add a new `Terraform` CI job that runs `terraform fmt -check -recursive` and `terraform validate`
- Runs in parallel with the existing Node.js test job
- Uses `hashicorp/setup-terraform@v3` and initializes with `-backend=false` (no AWS credentials needed)

## Test plan
- [ ] CI passes — Terraform format check succeeds
- [ ] CI passes — Terraform validate succeeds
- [ ] Existing Node.js tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)